### PR TITLE
 Remove Travis build status from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Fims QuickStart  [![Build Status](https://travis-ci.com/apache/fineract-cn-fims-web-app.svg?branch=develop)](https://travis-ci.com/apache/fineract-cn-fims-web-app) [![Docker Build](https://img.shields.io/docker/cloud/build/apache/fineract-cn-fims-web-app.svg)](https://hub.docker.com/r/apache/fineract-cn-fims-web-app/builds)
+# Fims QuickStart  [![Docker Build](https://img.shields.io/docker/cloud/build/apache/fineract-cn-fims-web-app.svg)](https://hub.docker.com/r/apache/fineract-cn-fims-web-app/builds)
 
 ## Setup
 


### PR DESCRIPTION
Due to the removal of the Travis build scripts from the project. The build status in the README.md is now misleading and needs to be removed.